### PR TITLE
Add cooldown utils and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -26,6 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "gh-pages": "^6.3.0",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import starterPlantImage from "../assets/plant_starter.png";
 import "./Home.css";
+import { formatTime, isCooldownOver, timeLeft } from "../utils/time";
 
 export default function Home() {
   const [plants, setPlants] = useState(() => {
@@ -37,25 +38,6 @@ export default function Home() {
     const updatedPlants = [...plants];
     updatedPlants[index].lastWateredAt = nowTime;
     setPlants(updatedPlants);
-  };
-
-  const formatTime = (ms) => {
-    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes}m ${seconds}s`;
-  };
-
-  const isCooldownOver = (lastWateredAt) => {
-    if (!lastWateredAt) return true;
-    const cooldown = 5 * 60 * 1000;
-    return now - new Date(lastWateredAt) >= cooldown;
-  };
-
-  const timeLeft = (lastWateredAt) => {
-    if (!lastWateredAt) return 0;
-    const cooldown = 5 * 60 * 1000;
-    return cooldown - (now - new Date(lastWateredAt));
   };
 
   return (
@@ -98,8 +80,8 @@ export default function Home() {
           <p style={{ color: "lightgray" }}>No plants yet. Start growing!</p>
         ) : (
           plants.map((plant, index) => {
-            const canWater = isCooldownOver(plant.lastWateredAt);
-            const remaining = timeLeft(plant.lastWateredAt);
+            const canWater = isCooldownOver(now, plant.lastWateredAt);
+            const remaining = timeLeft(now, plant.lastWateredAt);
 
             return (
               <div key={index} style={{ margin: "20px" }}>

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,18 @@
+export const DEFAULT_COOLDOWN = 5 * 60 * 1000; // 5 minutes
+
+export function formatTime(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+}
+
+export function isCooldownOver(now, lastWateredAt, cooldown = DEFAULT_COOLDOWN) {
+  if (!lastWateredAt) return true;
+  return now - new Date(lastWateredAt) >= cooldown;
+}
+
+export function timeLeft(now, lastWateredAt, cooldown = DEFAULT_COOLDOWN) {
+  if (!lastWateredAt) return 0;
+  return Math.max(0, cooldown - (now - new Date(lastWateredAt)));
+}

--- a/src/utils/time.test.js
+++ b/src/utils/time.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { formatTime, isCooldownOver, timeLeft, DEFAULT_COOLDOWN } from './time';
+
+describe('time utilities', () => {
+  it('formats milliseconds into minutes and seconds', () => {
+    expect(formatTime(0)).toBe('0m 0s');
+    expect(formatTime(61000)).toBe('1m 1s');
+  });
+
+  it('determines if cooldown is over', () => {
+    const now = new Date('2024-01-01T00:10:00Z');
+    const fiveMinutesAgo = new Date(now - DEFAULT_COOLDOWN);
+    const fourMinutesAgo = new Date(now - DEFAULT_COOLDOWN + 60_000);
+    expect(isCooldownOver(now, fiveMinutesAgo)).toBe(true);
+    expect(isCooldownOver(now, fourMinutesAgo)).toBe(false);
+    expect(isCooldownOver(now, null)).toBe(true);
+  });
+
+  it('calculates time left with non-negative result', () => {
+    const now = new Date('2024-01-01T00:10:00Z');
+    const fourMinutesAgo = new Date(now - DEFAULT_COOLDOWN + 60_000);
+    const sixMinutesAgo = new Date(now - DEFAULT_COOLDOWN - 60_000);
+    expect(timeLeft(now, fourMinutesAgo)).toBe(60_000);
+    expect(timeLeft(now, sixMinutesAgo)).toBe(0);
+    expect(timeLeft(now, null)).toBe(0);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   base: "/water-plants/",
   plugins: [react()],
+  test: {
+    environment: "node",
+  },
 });


### PR DESCRIPTION
## Summary
- extract helper functions into `src/utils/time.js`
- hook up util functions in `Home` page
- configure `vitest` and add sample unit tests
- update `package.json` with test script

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b69810adc832080d27538e6a18f45